### PR TITLE
Allow /occurrences/taxa/ to accept URL-style species ID

### DIFF
--- a/grails-app/conf/BiocacheHubsUrlMappings.groovy
+++ b/grails-app/conf/BiocacheHubsUrlMappings.groovy
@@ -8,7 +8,7 @@ class BiocacheHubsUrlMappings {
         "/occurrences/search"(controller: 'occurrence', action: 'list')
         "/occurrence/search"(controller: 'occurrence', action: 'list')
         "/occurrences/search/taxa"(controller: 'occurrence', action: 'taxaPost')
-        "/occurrences/taxa/$id"(controller: 'occurrence', action: 'taxa')
+        "/occurrences/taxa/$id**"(controller: 'occurrence', action: 'taxa')
         "/occurrences/assertions/add"(controller: 'assertions', action: 'addAssertion')
         "/occurrences/assertions/delete"(controller: 'assertions', action: 'deleteAssertion')
         "/occurrences/index"(controller: 'occurrence', action: 'index')


### PR DESCRIPTION
Extra slashes are a bonus, honest
