### PR TITLE
Fixed #216

### DIFF
--- a/grails-app/conf/defaultConfig.groovy
+++ b/grails-app/conf/defaultConfig.groovy
@@ -76,6 +76,7 @@ spatial.params = ""
 test.var = "test"
 // used to link temporary data resources back to an originating sandbox.
 sandbox.uploadSource=''
+advancedTaxaField = "taxa" // used in advanced form for the 4 taxa query inputs
 
 clubRoleForHub = "ROLE_ADMIN"
 // whether map or list is the default tab to show - empty for list and "mapView" for map

--- a/grails-app/controllers/au/org/ala/biocache/hubs/OccurrenceController.groovy
+++ b/grails-app/controllers/au/org/ala/biocache/hubs/OccurrenceController.groovy
@@ -67,15 +67,15 @@ class OccurrenceController {
 
         List taxaQueries = (ArrayList<String>) params.list("taxa") // will be list for even one instance
         log.debug "skin.useAlaBie = ${grailsApplication.config.skin.useAlaBie}"
+        log.debug "taxaQueries = ${taxaQueries} || q = ${requestParams.q}"
 
         if (grailsApplication.config.skin.useAlaBie?.toBoolean() &&
-                grailsApplication.config.bie.baseUrl &&
-                !params.q &&
-                taxaQueries &&
-                taxaQueries[0]) { // check for list with empty string
-            // taxa query - attempt GUID lookup via BIE
+                grailsApplication.config.bie.baseUrl && taxaQueries && taxaQueries[0]) {
+            // check for list with empty string
+            // taxa query - attempt GUID lookup
             List guidsForTaxa = webServicesService.getGuidsForTaxa(taxaQueries)
-            requestParams.q = postProcessingService.createQueryWithTaxaParam(taxaQueries, guidsForTaxa)
+            def additionalQ = (params.q) ? " AND " + params.q : "" // advanced search form can provide both taxa and q params
+            requestParams.q = postProcessingService.createQueryWithTaxaParam(taxaQueries, guidsForTaxa) + additionalQ
         } else if (!params.q && taxaQueries && taxaQueries[0]) {
             // Bypass BIE lookup and pass taxa query in as text
             List emptyGuidList = taxaQueries.clone().collect { it = ""} // list of empty strings, of equal size to taxaQueries

--- a/grails-app/views/home/_advanced.gsp
+++ b/grails-app/views/home/_advanced.gsp
@@ -2,7 +2,7 @@
 <g:render template="/layouts/global"/>
 <form name="advancedSearchForm" id="advancedSearchForm" action="${request.contextPath}/advancedSearch" method="POST">
     <input type="text" id="solrQuery" name="q" style="position:absolute;left:-9999px;" value="${params.q}"/>
-    <input type="hidden" name="nameType" value="matched_name_children"/>
+    <input type="hidden" name="nameType" value="${grailsApplication.config.advancedTaxaField?:'matched_name_children'}"/>
     <b><g:message code="advancedsearch.title01" default="Find records that have"/></b>
     <table border="0" width="100" cellspacing="2" class="compact">
         <thead/>


### PR DESCRIPTION
Advanced search taxa inputs configurable to use "taxa=foo" query
instead of "q= matched_name_children:foo"