### PR TITLE
Fix for HTML entity biocache.queryContext

### DIFF
--- a/grails-app/assets/javascripts/map.common.js
+++ b/grails-app/assets/javascripts/map.common.js
@@ -140,7 +140,10 @@ function getExistingParams() {
     delete paramsObj.lat;
     delete paramsObj.lon;
     delete paramsObj.radius;
-    paramsObj.qc = BC_CONF.queryContext;
+    var decoder = document.createElement("textarea");
+    decoder.innerHTML = decodeURI(BC_CONF.queryContext);
+    paramsObj.qc = decoder.value;
+    //otherwise get context like "Isle of Man" as %26quot%3BIsle of Man%26quot%3B (encoded html entities), which never matches any records
     return $.param(paramsObj);
 }
 


### PR DESCRIPTION
If biocache.queryContext is quoted (e.g. cl28:"Isle of Man") or I imagine if it contains other characters like & that can be converted into HTML entities, then spatial searches fail to find any records or species because it becomes encoded. This fix unencodes the queryContext.