### PR TITLE
fixed #350

### DIFF
--- a/grails-app/assets/javascripts/search.js
+++ b/grails-app/assets/javascripts/search.js
@@ -1255,15 +1255,15 @@ function loadFacetsContent(facetName, fsort, foffset, facetLimit, replaceFacets)
                     //console.log("label", label, facetName, el);
                     var fqParam = (el.fq) ? encodeURIComponent(el.fq) : facetName + ":" + ((encodeFq) ? encodeURIComponent(fqEsc) : fqEsc) ;
                     //var link = BC_CONF.searchString.replace("'", "&apos;") + "&fq=" + fqParam;
-                    
+
                     //NC: 2013-01-16 I changed the link so that the search string is uri encoded so that " characters do not cause issues 
                     //Problematic URL http://biocache.ala.org.au/occurrences/search?q=lsid:urn:lsid:biodiversity.org.au:afd.taxon:b76f8dcf-fabd-4e48-939c-fd3cafc1887a&fq=geospatial_kosher:true&fq=state:%22Australian%20Capital%20Territory%22
                     var link = BC_CONF.searchString + "&fq=" + fqParam;
                     //console.log(link)
                     var rowType = (i % 2 == 0) ? "normalRow" : "alternateRow";
                     html += "<tr class='" + rowType + "'><td>" +
-                        "<input type='checkbox' name='fqs' class='fqs' value='"  + fqParam +
-                        "'/></td><td class='multiple-facet-value'><a href=\"" + link + "\"> " + label + "</a></td><td class='multiple-facet-count'>" + el.count.toLocaleString() + "</td></tr>";
+                        "<input type='checkbox' name='fqs' class='fqs' value=\""  + fqParam +
+                        "\"/></td><td class='multiple-facet-value'><a href=\"" + link + "\"> " + label + "</a></td><td class='multiple-facet-count'>" + el.count.toLocaleString() + "</td></tr>";
                 }
                 if (i == facetLimit - 1) {
                     //console.log("got to end of page of facets: " + i);


### PR DESCRIPTION
fixed #350

Because **encodeURIComponent doesn't encode single quote, when fqParam contains '. the value of the input is not properly constructed.**

<img width="572" alt="Screen Shot 2020-04-07 at 10 20 20 am" src="https://user-images.githubusercontent.com/61677987/78617059-6f4fb900-78b9-11ea-84a0-7ccf4deebe17.png">

for example when fqParam = taxon_name%3A%22'Ochlerotatus'%20daliensis%22
<input type="checkbox" name="fqs" class="fqs" value="taxon_name%3A%22" ochlerotatus'%20daliensis%22'="">

The solution is, since encodeURIComponent encodes double quote, then fqParam already has double quotes escaped, use " to construct the value.

Did a test with the above fix.
Selected these fitlers (total 235 records expected)
<img width="591" alt="Screen Shot 2020-04-07 at 10 07 31 am" src="https://user-images.githubusercontent.com/61677987/78616516-c81e5200-78b7-11ea-8133-e57339ee049a.png">

Actual result record amount is correct.
<img width="1269" alt="Screen Shot 2020-04-07 at 10 07 45 am" src="https://user-images.githubusercontent.com/61677987/78616593-fb60e100-78b7-11ea-97ee-16bf77b5f43e.png">

And the URL is correct.

`http://localhost:8080/ala-hub/occurrences/search?q=*:*&fq=(taxon_name:"'Ochlerotatus'" OR taxon_name:"'Ochlerotatus' ('Finlaya') britteni" OR taxon_name:"'Ochlerotatus' ('Finlaya') candidoscutellum" OR taxon_name:"'Ochlerotatus' ('Finlaya') monocellatus" OR taxon_name:"'Ochlerotatus' ('Finlaya') subauridorsum" OR taxon_name:"'Ochlerotatus' ('Finlaya') wasselli" OR taxon_name:"'Ochlerotatus' daliensis" OR taxon_name:"'Stolasterias")`


Did another test which includes filters with both ' and ".
Result records amount is wrong because of [https://github.com/AtlasOfLivingAustralia/biocache-service/issues/440](url) but constructed URL is correct.
<img width="586" alt="Screen Shot 2020-04-07 at 10 13 24 am" src="https://user-images.githubusercontent.com/61677987/78616769-8cd05300-78b8-11ea-82f3-c405eef242c3.png">

`http://localhost:8080/ala-hub/occurrences/search?q=*:*&fq=(taxon_name:""Cyclophora" lechriostropha" OR taxon_name:""Cyclophora" rhodobapta" OR taxon_name:""Cyclophora" sticta" OR taxon_name:"'Ochlerotatus'" OR taxon_name:"'Ochlerotatus' ('Finlaya') britteni" OR taxon_name:"'Ochlerotatus' ('Finlaya') candidoscutellum" OR taxon_name:"'Stolasterias")`
