### PR TITLE
Fix annotation icons

### DIFF
--- a/grails-app/views/occurrence/show.gsp
+++ b/grails-app/views/occurrence/show.gsp
@@ -682,7 +682,7 @@
                 </p>
                 <p class="deleteAnnotation" style="display:block;">
                     <a class="deleteAnnotationButton btn btn-danger" href="#">
-                        <i class="glyphicon-remove"> </i> &nbsp;
+                        <i class="glyphicon glyphicon-remove"> </i> &nbsp;
                         <g:message code="show.userannotationtemplate.p02.navigator" default="Delete this annotation"/>
                         <span class="deleteAssertionSubmitProgress" style="display:none;">
                             <asset:image src="indicator.gif" alt="indicator icon"/>
@@ -692,7 +692,7 @@
                 <g:if test="${isCollectionAdmin}">
                     <p class="verifyAnnotation" style="display:none;">
                         <a class="verifyAnnotationButton btn btn-default"  href="#verifyRecordModal" data-toggle="modal">
-                            <i class="glyphicon-thumbs-up"> </i> &nbsp;
+                            <i class="glyphicon glyphicon-thumbs-up"> </i> &nbsp;
                             <g:message code="show.userannotationtemplate.p03.navigator" default="Verify this annotation"/></a>
                     </p>
                 </g:if>


### PR DESCRIPTION
Just a minor icon fix in annotations code:

![2020-01-20-13_07_29-screenshot](https://user-images.githubusercontent.com/180085/80199899-240c0900-8622-11ea-86a7-81f6b82cebcf.png)
