### PR TITLE
issue #387 : Remove hardcoded /ws in alerts button handler

### DIFF
--- a/grails-app/assets/javascripts/search.js
+++ b/grails-app/assets/javascripts/search.js
@@ -488,9 +488,9 @@ $(document).ready(function() {
         var url = alertsUrlPrefix + "/ws/" + methodName + "?";
         var searchParamsEncoded = encodeURIComponent(decodeURIComponent(BC_CONF.searchString)); // prevent double encoding of chars
         url += "queryDisplayName="+encodeURIComponent(query);
-        url += "&baseUrlForWS=" + encodeURIComponent(BC_CONF.biocacheServiceUrl.replace(/\/ws$/,""));
+        url += "&baseUrlForWS=" + encodeURIComponent(BC_CONF.biocacheServiceUrl);
         url += "&baseUrlForUI=" + encodeURIComponent(BC_CONF.serverName);
-        url += "&webserviceQuery=%2Fws%2Foccurrences%2Fsearch" + searchParamsEncoded;
+        url += "&webserviceQuery=%2Foccurrences%2Fsearch" + searchParamsEncoded;
         url += "&uiQuery=%2Foccurrences%2Fsearch" + searchParamsEncoded;
         url += "&resourceName=" + encodeURIComponent(BC_CONF.resourceName);
         //console.log("url", query, methodName, searchParamsEncoded, url);


### PR DESCRIPTION
Removes the hardcoded `/ws` from the alerts button handler.

This should not have any effect on the ALA, but it will make it possible for other Living Atlas installations to use the alerts button if the biocache-service path doesn't start with `/ws`