### PR TITLE
apply profile preference when specified is disabled

### DIFF
--- a/grails-app/assets/javascripts/search.js
+++ b/grails-app/assets/javascripts/search.js
@@ -575,8 +575,19 @@ $(document).ready(function() {
             url = appendURL(url, 'fq=' + encodeURIComponent(filters[i]).replace(/%20/g, "+").replace(/[()]/g, escape));
         }
 
+        // profile in URL may be invalid, replace it with the actual profile being used
+        url = replaceInvalidProfile(url, $.url().param('qualityProfile'), $(this).attr('data-profile'))
+
         window.location.href = url;
     })
+
+    function replaceInvalidProfile(url, profileInURL, actualProfile) {
+        if (profileInURL !== undefined && profileInURL !== actualProfile) {
+            url = removeFromURL(url, "qualityProfile=", false);
+            url = prependURL(url, "qualityProfile=" + encodeURIComponent(actualProfile).replace(/%20/g, "+").replace(/[()]/g, escape), true);
+        }
+        return url
+    }
 
     function removeDuplicates(data) {
         var unique = [];
@@ -982,9 +993,10 @@ $(document).ready(function() {
         // get current url
         var url = $(location).attr('href');
 
-        var fitlers = $("form#filterRefineForm").find("td.filternames");
-        var filterStatus = $("form#filterRefineForm").find(":input.filters");
-        var expanded = $("form#filterRefineForm").find(".expanded");
+        var filterForm = $("form#filterRefineForm")
+        var fitlers = filterForm.find("td.filternames");
+        var filterStatus = filterForm.find(":input.filters");
+        var expanded = filterForm.find(".expanded");
 
         // replace url encoded %20 with '+' because groovy encodes space to '+'
         $.each(filterStatus, function( i, status ) {
@@ -1013,6 +1025,9 @@ $(document).ready(function() {
                 url = removeFiltersFromFq($(fitlers[i]).data("filters"), url);
             }
         })
+
+        // profile in URL may be invalid, replace it with the actual profile being used
+        url = replaceInvalidProfile(url, $.url().param('qualityProfile'), filterForm.attr('data-profile'))
 
         window.location.href = url;
     })

--- a/grails-app/services/au/org/ala/biocache/hubs/QualityService.groovy
+++ b/grails-app/services/au/org/ala/biocache/hubs/QualityService.groovy
@@ -152,6 +152,10 @@ class QualityService {
         }
     }
 
+    boolean isProfileValid(profileName) {
+        return profileName && isProfileEnabled(profileName)
+    }
+
     def clearRecordCountCache() {
         recordCountCache.invalidateAll()
     }

--- a/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
+++ b/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
@@ -647,7 +647,7 @@ class WebServicesService {
 
     def populateProfile(requestParams) {
         // force set the profile if none provided
-        if (dataQualityEnabled && !requestParams.qualityProfile && !requestParams.disableAllQualityFilters) {
+        if (dataQualityEnabled && !qualityService.isProfileValid(requestParams.qualityProfile) && !requestParams.disableAllQualityFilters) {
             requestParams.qualityProfile = qualityService.activeProfile()?.shortName
         }
     }

--- a/grails-app/views/occurrence/list.gsp
+++ b/grails-app/views/occurrence/list.gsp
@@ -414,7 +414,7 @@
                                             </div>
                                             <div class="modal-body">
                                                 <div id="dynamic" class="tableContainer">
-                                                    <form name="filterRefineForm" id="filterRefineForm">
+                                                    <form name="filterRefineForm" id="filterRefineForm" data-profile="${params.qualityProfile}">
                                                         <table class="table table-bordered table-condensed table-striped scrollTable">
                                                             <thead class="fixedHeader">
                                                             <tr class="tableHead">
@@ -553,7 +553,7 @@
                                                     <p id="excluded" style="margin-bottom: 0"><i class="fa fa-circle-o-notch fa-spin exclude-loader"></i><span class="exclude-count-label"></span> <g:message code="dq.excluded.count" default="records are excluded by this category"/></p>
                                                     <a id="view-excluded" class="btn btn-link" href="#view-excluded" target="_blank" style="text-decoration: none; padding: 0"><g:message code="dq.view.excluded" default="View excluded records"/></a>
                                                     <p id="filter-value" style="margin-bottom: 0"></p>
-                                                    <button id='expandfilters' class="btn btn-link tooltips" data-dismiss="modal" title="<g:message code="dq.pop.out" default="Convert this data quality filter into separate filter queries you can include/exclude individually"></g:message>" style="text-decoration: none; padding: 0"><g:message code="dq.categoryinfo.dlg.expandbutton.text" default="Expand and edit filters"/></button>
+                                                    <button id='expandfilters' class="btn btn-link tooltips" data-dismiss="modal" data-profile=${params.qualityProfile} title="<g:message code="dq.pop.out" default="Convert this data quality filter into separate filter queries you can include/exclude individually"></g:message>" style="text-decoration: none; padding: 0"><g:message code="dq.categoryinfo.dlg.expandbutton.text" default="Expand and edit filters"/></button>
 
                                                     <table class="table table-bordered table-condensed table-striped scrollTable" id="DQDetailsTable" style="margin-top: 20px">
                                                         <thead class="fixedHeader">


### PR DESCRIPTION
Old code only applies default profile when there's no profile specified in URL. If a disabled profile being specified, we won't apply the default profile.

Now we changed to apply default profile when the specified profile is null or disabled.

