### PR TITLE
$.param() doesn't format object correctly

### DIFF
--- a/grails-app/assets/javascripts/map.common.js
+++ b/grails-app/assets/javascripts/map.common.js
@@ -178,7 +178,7 @@ function getExistingParams() {
     decoder.innerHTML = decodeURI(BC_CONF.queryContext);
     paramsObj.qc = decoder.value;
     //otherwise get context like "Isle of Man" as %26quot%3BIsle of Man%26quot%3B (encoded html entities), which never matches any records
-    return $.param(paramsObj);
+    return $.param(paramsObj, true);
 }
 
 function drawWktObj(wktString) {


### PR DESCRIPTION
For issue https://github.com/AtlasOfLivingAustralia/biocache-hubs/issues/437

**before the change**
http://dev.ala.org.au:8081/ala-hub/occurrences/search?q=*:*&qualityProfile=ALA&fq[]=basis_of_record:"EnvironmentalDNA"&fq[]=occurrence_status:"present"&qc=&wkt=MULTIPOLYGON(((130.2099609375+-20.863944849076894,130.2099609375 -47.2083742134663,149.2822265625 -47.2083742134663,149.2822265625 -20.863944849076894,130.2099609375 -20.863944849076894)))

- see there's fq[]=xxx&fq[]=xxx;


**with the change**
http://dev.ala.org.au:8081/ala-hub/occurrences/search?q=*:*&qualityProfile=ALA&fq=basis_of_record:"EnvironmentalDNA"&fq=occurrence_status:"present"&qc=&wkt=MULTIPOLYGON(((129.4189453125+-20.205501205844214,129.4189453125 -40.70146360360458,156.7529296875 -40.70146360360458,156.7529296875 -20.205501205844214,129.4189453125 -20.205501205844214)))

---

That's because we use the `$.param()` to transform a JS object into strings

<img width="471" alt="截屏2021-04-23 下午4 40 03" src="https://user-images.githubusercontent.com/61677987/115829733-a9531500-a452-11eb-8049-b71668ac4347.png">

According to [https://api.jquery.com/jquery.param/](https://api.jquery.com/jquery.param/) 
```
// <=1.3.2:
$.param({ a: [ 2, 3, 4 ] }); // "a=2&a=3&a=4"
// >=1.4:
$.param({ a: [ 2, 3, 4 ] }); // "a[]=2&a[]=3&a[]=4"
```
So to emulate the behavior of `$.param()` prior to jQuery 1.4, we can set the traditional `argument` to `true`