### PR TITLE
Fix jquery.i18n load errors

### DIFF
--- a/grails-app/assets/javascripts/biocache-hubs.js
+++ b/grails-app/assets/javascripts/biocache-hubs.js
@@ -4,6 +4,7 @@
 /************************************************************\
  * i18n
  \************************************************************/
+//= require jquery_i18n
 if (typeof BC_CONF != 'undefined' && BC_CONF.hasOwnProperty('contextPath')) {
     jQuery.i18n.properties({
         name: 'messages',

--- a/grails-app/assets/javascripts/leafletPlugins.js
+++ b/grails-app/assets/javascripts/leafletPlugins.js
@@ -1,4 +1,4 @@
-
+//= require jquery_i18n
 //= require leaflet/leaflet-src.js
 //= require leaflet-fullscreen.js
 //= require leaflet-plugins/layer/tile/Google.js

--- a/grails-app/views/home/index.gsp
+++ b/grails-app/views/home/index.gsp
@@ -28,6 +28,8 @@
         <script src="https://maps.google.com/maps/api/js" type="text/javascript"></script>
     </g:else>
 
+    <asset:javascript src="jquery_i18n.js"/>
+
     <script type="text/javascript">
         // global var for GSP tags/vars to be passed into JS functions
         var BC_CONF = {


### PR DESCRIPTION
This is a PR for discussion. I have from time to time errors about jquery.i18n not loaded on time or properly. For instance, in a recent install ala-hub I have 3 errors caused by this:

- the home page spatial tab does not load the map
- the occurrences map also fails
- the explore your map area also fails  

I get similar errors in the file patched caused by:
`TypeError: Cannot read property 'properties' of undefined`

So I added on each file that uses the jQuery.i18n and fails the `require` and the errors disappeared.

I don't understand well how this works sometimes and sometimes fails without patching it.

As I'm not a grails expert, I created this PR to discuss this issue and this possible fix.
