### PR TITLE
no strip . in taxon

### DIFF
--- a/src/main/groovy/au/org/ala/biocache/hubs/AdvancedSearchParams.groovy
+++ b/src/main/groovy/au/org/ala/biocache/hubs/AdvancedSearchParams.groovy
@@ -118,7 +118,7 @@ class AdvancedSearchParams implements Validateable {
         // iterate over the taxa search inputs and if lsid is set use it otherwise use taxa input
         taxonText.each { tt ->
             if (tt) {
-                taxas.add(stripChars(quoteText(tt)));
+                taxas.add(quoteText(tt));
             }
         }
 


### PR DESCRIPTION
for issue https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/461


So with user input:
<img width="263" alt="截屏2021-07-21 下午4 22 32" src="https://user-images.githubusercontent.com/61677987/126441383-e9ce8ef1-73c1-40eb-bc5f-d9229a510422.png">


results in `http://dev.ala.org.au:8081/ala-hub/occurrences/search?taxa=111.+OR+222+.+OR+333.+333.+333++.+OR+444.555.666.`
            
in old code it will be 
`https://biocache-dq-test.ala.org.au/occurrences/search?taxa=111+OR+222++OR+333+333+333+++OR++444555666`
