### PR TITLE
Handle 404 from taxa query

### DIFF
--- a/grails-app/controllers/au/org/ala/biocache/hubs/OccurrenceController.groovy
+++ b/grails-app/controllers/au/org/ala/biocache/hubs/OccurrenceController.groovy
@@ -266,7 +266,7 @@ class OccurrenceController {
         log.debug "taxaQueries = ${taxaQueries} || q = ${requestParams.q}"
 
         if (grailsApplication.config.skin.useAlaBie?.toString()?.toBoolean() &&
-                grailsApplication.config.bie.baseUrl && taxaQueries && taxaQueries[0]) {
+                grailsApplication.config.bieService.baseUrl && taxaQueries && taxaQueries[0]) {
             // check for list with empty string
             // taxa query - attempt GUID lookup
             List guidsForTaxa = webServicesService.getGuidsForTaxa(taxaQueries)

--- a/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
+++ b/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
@@ -315,9 +315,13 @@ class WebServicesService {
         JSONObject guidsJson = getJsonElements(url)
 
         taxaQueries.each { key ->
-            def match = guidsJson.get(key)[0]
-            def guid = (match?.acceptedIdentifier) ? match?.acceptedIdentifier : match?.identifier
-            guids.add(guid)
+            if (guidsJson) {
+                def match = guidsJson.get(key)[0]
+                def guid = (match?.acceptedIdentifier) ? match?.acceptedIdentifier : match?.identifier
+                guids.add(guid)
+            } else {
+                guids.add("")
+            }
         }
 
         return guids


### PR DESCRIPTION
for https://github.com/AtlasOfLivingAustralia/biocache-hubs/issues/471

With this change, when bie-service returns 404 (so an empty JSONObject is returned)

1. for the query `/occurrences/search?taxa=acacia+dealbata`, it will search for `text:"acacia dealbata"`
2. for an advanced search `taxa = aaa or bbb`,  it will search for `(text:"aaa" OR text:"bbb")`