### PR TITLE
Issue 370 display sound metadata

### DIFF
--- a/grails-app/controllers/au/org/ala/biocache/hubs/OccurrenceController.groovy
+++ b/grails-app/controllers/au/org/ala/biocache/hubs/OccurrenceController.groovy
@@ -387,6 +387,8 @@ class OccurrenceController {
                     }
                 }
 
+                populateSound(record)
+
                 String userEmail = authService?.getEmail()
                 Boolean isCollectionAdmin = false
                 Boolean userHasRoleAdmin = authService?.userInRole(CASRoles.ROLE_ADMIN)
@@ -472,6 +474,25 @@ class OccurrenceController {
         }
     }
 
+    /**
+     * Retrieve sound detail link and sound file metadata
+     */
+    private def populateSound(JSONObject record) {
+        if (record?.sounds) {
+            // record.sounds is a list of mediaDTO
+            for (JSONObject mediaDTO in record.sounds) {
+                String soundUrl = mediaDTO?.alternativeFormats?.'audio/mpeg'
+                if (soundUrl) {
+                    String[] parts = soundUrl.split("imageId=")
+                    if (parts.length >= 2) {
+                        log.debug("image id = " + parts[1])
+                        mediaDTO.alternativeFormats.'detailLink' = "${grailsApplication.config.images.baseUrl}/image/${parts[1].encodeAsURL()}"
+                        mediaDTO.metadata = webServicesService.getImageMetadata(parts[1])
+                    }
+                }
+            }
+        }
+    }
     /**
      * Go to the next occurrences of the search results
      * Use the Navigation DTO from session (if available)

--- a/grails-app/i18n/messages_en.properties
+++ b/grails-app/i18n/messages_en.properties
@@ -152,6 +152,7 @@ show.sidebar03.image.license = Image license
 show.sidebar03.caption=Caption
 show.sidebar03.image.title=Title
 show.sidebardiv.occurrenceimages.navigator01 = View image details
+show.sidebardiv.occurrencesounds.navigator01 = View sound details
 show.sidebardiv.occurrenceimages.navigator02 = View original image
 show.occurrencemap.title = Location of record
 show.soundsheader.title = Sounds

--- a/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
+++ b/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
@@ -263,6 +263,12 @@ class WebServicesService {
     }
 
     @Cacheable('longTermCache')
+    def getImageMetadata(String imageId) {
+        def url = "${grailsApplication.config.images.baseUrl}/ws/image/${imageId.encodeAsURL()}.json"
+        getJsonElements(url)
+    }
+
+    @Cacheable('longTermCache')
     Map getLayersMetaData() {
         Map layersMetaMap = [:]
         def url = "${grailsApplication.config.layersservice.baseUrl}/layers"

--- a/grails-app/views/occurrence/_recordSidebar.gsp
+++ b/grails-app/views/occurrence/_recordSidebar.gsp
@@ -267,21 +267,37 @@
     <g:if test="${record.sounds}">
         <div class="sidebar">
             <h3 id="soundsHeader" style="margin: 20px 0 0 0;"><g:message code="show.soundsheader.title" default="Sounds"/></h3>
-            <div class="row">
-                <div id="audioWrapper" class="col-md-12">
-                    <audio src="${record.sounds.get(0)?.alternativeFormats?.'audio/mpeg'}" preload="auto" />
-                    <div class="track-details">
-                        ${record.raw.classification.scientificName}
+            <div id="occurrenceSounds" style="margin-top:5px;">
+                <g:each in="${record.sounds}" var="sound">
+                    <div class="row">
+                        <div id="audioWrapper" class="col-md-12">
+                            <audio src="${sound?.alternativeFormats?.'audio/mpeg'}" preload="auto" />
+                            <div class="track-details">
+                                ${record.raw.classification.scientificName}
+                            </div>
+                        </div>
                     </div>
-                </div>
+                    <p>
+                        <g:message code="show.sidebar04.p" default="Please press the play button to hear the sound file associated with this occurrence record."/>
+                    </p>
+
+                    <g:if test="${sound?.metadata?.rights || record.raw.occurrence.rights}">
+                        <cite><b><g:message code="show.sidebar04.cite" default="Rights"/>:</b> ${sound?.metadata?.rights ?: record.raw.occurrence.rights}</cite><br/>
+                    </g:if>
+                    <g:if test="${sound?.metadata?.rightsHolder || record.raw.occurrence.rightsholder}">
+                        <cite><b><g:message code="show.sidebar03.cite03" default="Rights holder"/>:</b> ${sound?.metadata?.rightsHolder ?: record.raw.occurrence.rightsholder}</cite><br/>
+                    </g:if>
+
+                    <g:if test="${sound?.metadata?.license}">
+                        <cite><b><g:message code="show.sidebar03.image.license" default="License"/>:</b> ${sound?.metadata?.license}</cite><br/>
+                    </g:if>
+
+                    <g:if test="${grailsApplication.config.skin.useAlaImageService.toBoolean() && sound?.alternativeFormats?.detailLink}">
+                        <a href="${sound?.alternativeFormats?.detailLink}" target="_blank"><g:message code="show.sidebardiv.occurrencesounds.navigator01" default="View sound details"/></a><br/>
+                    </g:if>
+                    <br/>
+                </g:each>
             </div>
-            <g:if test="${record.raw.occurrence.rights}">
-                <br/>
-                <cite><b><g:message code="show.sidebar04.cite" default="Rights"/>:</b> ${record.raw.occurrence.rights}</cite>
-            </g:if>
-            <p>
-                <g:message code="show.sidebar04.p" default="Please press the play button to hear the sound file associated with this occurrence record."/>
-            </p>
         </div>
     </g:if>
     <g:if test="${record.raw.lastModifiedTime && record.processed.lastModifiedTime}">


### PR DESCRIPTION
for https://github.com/AtlasOfLivingAustralia/biocache-hubs/issues/370

**webpage is also updated to display a list of sound files.** 

**So when there are metadata (license, rights, rights holder) found for the files:**
<img width="826" alt="Screen Shot 2021-08-17 at 11 28 03 am" src="https://user-images.githubusercontent.com/61677987/129649751-df93bac6-7919-4db3-81f3-20be6eae0cc9.png">

**when no metadata found at all:**

<img width="787" alt="Screen Shot 2021-08-17 at 11 38 45 am" src="https://user-images.githubusercontent.com/61677987/129649983-060e0256-73b4-4088-a815-f911e1e97575.png">


