### PR TITLE
explicitly set 'user_facets' as String in cookie

### DIFF
--- a/grails-app/assets/javascripts/search.js
+++ b/grails-app/assets/javascripts/search.js
@@ -165,7 +165,8 @@ $(document).ready(function() {
 
         //Check user has selected at least 1 facet
         if (selectedFacets.length > 0 && selectedFacets.length  <= BC_CONF.maxFacets) {
-            // save facets to the user_facets cookie
+            // save facets to the user_facets cookie as string
+            $.cookie.json = false;
             $.cookie("user_facets", selectedFacets, { expires: 7 });
             // reload page
             document.location.reload(true);


### PR DESCRIPTION
fix for issue https://github.com/AtlasOfLivingAustralia/biocache-hubs/issues/453

the issue can be reproduced this way:

1. expand/collspase data-quality profile details
2. go to '**Customise filters**', make whatever changes and click '**Update**' 

The issue is, in step 1, the `$.cookie.json` is set to true so cookies values are jsonfied. 
Then in step 2, Javascropt string array is jsonfiled which is not what we want. 

The fix is to set `$.cookie.json = false` before setting cookie value.


We don't need to worry about cookie read. Because each read function already knows if the value in cookie is JSON object or string.

