### PR TITLE
the converted value should be put back to map to be used somewhere else

### DIFF
--- a/grails-app/assets/javascripts/search.js
+++ b/grails-app/assets/javascripts/search.js
@@ -29,13 +29,13 @@ $(document).ready(function() {
         $('.exclude-loader').hide();
         for (var key in data) {
             var categoryEnabled = $('.exclude-count-label[data-category='+key+']').data('enabled')
-            var count = categoryEnabled ? (new Intl.NumberFormat()).format(parseInt(data[key])) : '0';
-            $('.exclude-count-label[data-category='+key+']').text(count).show();
+            data[key] = categoryEnabled ? (new Intl.NumberFormat()).format(parseInt(data[key])) : '0';
+            $('.exclude-count-label[data-category='+key+']').text(data[key]).show();
 
-            if (count === '0') {
-                $('.exclude-count-facet[data-category=' + key + ']').text('(' + count + ')').show();
+            if (data[key] === '0') {
+                $('.exclude-count-facet[data-category=' + key + ']').text('(' + data[key] + ')').show();
             } else {
-                $('.exclude-count-facet[data-category=' + key + ']').text('(-' + count + ')').show();
+                $('.exclude-count-facet[data-category=' + key + ']').text('(-' + data[key] + ')').show();
             }
         }
         excludeCounts = data;
@@ -442,10 +442,10 @@ $(document).ready(function() {
         $('#DQDetailsModal .modal-body #filter-value').html("<b>Filter applied: </b><i>fq=" + fq + "</i>");
         $("#view-excluded").attr('href', dqInverse);
 
-        if (excludeCounts[dqCategoryLabel]) {
+        if (excludeCounts[dqCategoryLabel] !== '0') {
             $("#excluded .exclude-count-label").text(excludeCounts[dqCategoryLabel]).removeData('category').removeAttr('category');
         } else {
-            $("#excluded .exclude-count-label").text('').data('category', dqCategoryLabel).attr('data-category', dqCategoryLabel);
+            $("#excluded .exclude-count-label").text(excludeCounts[dqCategoryLabel]).data('category', dqCategoryLabel).attr('data-category', dqCategoryLabel);
         }
 
         var pos = 0;


### PR DESCRIPTION
for https://github.com/AtlasOfLivingAustralia/biocache-hubs/issues/495

This is the original change, I made this change so `0` excluded will be shown as `(0)` instead of `-(0)`
<img width="2161" alt="Screen Shot 2021-09-08 at 11 26 16 am" src="https://user-images.githubusercontent.com/61677987/132431004-883f9131-649c-4291-996c-10f6f6726ebb.png">

But I forgot to put the converted value back to `data` map


for 
```
if (excludeCounts[dqCategoryLabel]) {
    $("#excluded .exclude-count-label").text(excludeCounts[dqCategoryLabel]).removeData('category').removeAttr('category');
} else {
    $("#excluded .exclude-count-label").text('').data('category', dqCategoryLabel).attr('data-category', dqCategoryLabel);
}
```

old code only goes to else when `==0` that means the category is disabled. now if excludeCount == 0 we got there. Seems there's no issue.