### PR TITLE
fixed margin being removed because layer is removed after being added.

### DIFF
--- a/grails-app/assets/vendor/leaflet/leaflet-src.js
+++ b/grails-app/assets/vendor/leaflet/leaflet-src.js
@@ -8553,12 +8553,16 @@ jQuery.i18n.properties({
             for (i = 0; i < inputsLen; i++) {
                 input = inputs[i];
                 obj = this._layers[input.layerId];
+                if (!input.checked && this._map.hasLayer(obj.layer)) {
+                    this._map.removeLayer(obj.layer);
+                }
+            }
 
+            for (i = 0; i < inputsLen; i++) {
+                input = inputs[i];
+                obj = this._layers[input.layerId];
                 if (input.checked && !this._map.hasLayer(obj.layer)) {
                     this._map.addLayer(obj.layer);
-
-                } else if (!input.checked && this._map.hasLayer(obj.layer)) {
-                    this._map.removeLayer(obj.layer);
                 }
             }
 


### PR DESCRIPTION
for issue https://github.com/AtlasOfLivingAustralia/biocache-hubs/issues/389

When we switch between layers, 1 layer is removed and 1 added.

The direct cause for #389 is `onAdd` is called and then `onRemove` which makes the margin to be `0`

```
onAdd: function(map, insertAtTheBottom) {
    // ...
    map._controlCorners['bottomright'].style.marginBottom = "20px";

    this._reset();
    this._update();
},

onRemove: function(map) {
    // ....
    map._controlCorners['bottomright'].style.marginBottom = "0em";
},
```

<br/>

https://github.com/AtlasOfLivingAustralia/biocache-hubs/blob/bb5232b37ac35d44856ca49b4c1dbe22f1c24fd7/grails-app/assets/vendor/leaflet-plugins/layer/tile/Google.js#L34-L69

<br/>

My change is safe because it effectively does same thing, only the order is changed. It makes sure `onAdd` is called after `onRemove`