### PR TITLE
Update charts plugin with i18n support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
 
     if(!inplace) {
         compile "au.org.ala.plugins.grails:images-client-plugin:1.2", noCache
-        compile "au.org.ala.plugins.grails:ala-charts-plugin:2.0.1", noCache
+        compile "au.org.ala.plugins.grails:ala-charts-plugin:2.1.2", noCache
     }
 
 }


### PR DESCRIPTION
Thanks to @biodivAtlasAT for the [PR](https://github.com/AtlasOfLivingAustralia/ala-charts-plugin/pull/8) and @djtfmartin for the review.

With this PR:

![image](https://user-images.githubusercontent.com/180085/161043465-63e4b068-6716-48dc-a8b0-3711d5901198.png)

Closes #541 .