### PR TITLE
Show vernacular names optionally

### DIFF
--- a/grails-app/taglib/au/org/ala/biocache/hubs/OccurrenceTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/biocache/hubs/OccurrenceTagLib.groovy
@@ -735,7 +735,7 @@ class OccurrenceTagLib {
                     span(class:'occurrenceNames', occurrence.raw_scientificName)
                 }
 
-                if (occurrence.vernacularName || occurrence.raw_vernacularName) {
+                if (grailsApplication.config.getProperty('vernacularName.show', Boolean, true) && occurrence.vernacularName || occurrence.raw_vernacularName) {
                     mkp.yieldUnescaped("&nbsp;|&nbsp;")
                     span(class:'occurrenceNames', occurrence.vernacularName?:occurrence.raw_vernacularName)
                 }

--- a/grails-app/views/occurrence/_recordCore.gsp
+++ b/grails-app/views/occurrence/_recordCore.gsp
@@ -2,6 +2,7 @@
 %{--<% Map fieldsMap = new HashMap(); pageContext.setAttribute("fieldsMap", fieldsMap); %>--}%
 <%-- g:set target="${fieldsMap}" property="aKey" value="value for a key" /--%>
 <g:set var="fieldsMap" value="${[:]}"/>
+<g:set var="showVernacularName" value="${grailsApplication.config.getProperty('vernacularName.show', Boolean, true)}"/>
 <div id="occurrenceDataset">
 <g:render template="sandboxUploadSourceLinks" model="[dataResourceUid: record?.raw?.attribution?.dataResourceUid]" />
 <h3><g:message code="recordcore.occurencedataset.title" default="Dataset"/></h3>
@@ -473,6 +474,7 @@
         <br/><span class="originalValue"><g:message code="recordcore.tr02" default="Supplied as"/> "${record.raw.classification.taxonRank}"</span>
     </g:if>
 </alatag:occurrenceTableRow>
+<g:if test="${showVernacularName}">
 <!-- Common name -->
 <alatag:occurrenceTableRow annotate="false" section="taxonomy" fieldCode="commonName" fieldName="Common name">
     ${fieldsMap.put("vernacularName", true)}
@@ -486,6 +488,7 @@
         <br/><span class="originalValue"><g:message code="recordcore.cn.01" default="Supplied common name"/> "${record.raw.classification.vernacularName}"</span>
     </g:if>
 </alatag:occurrenceTableRow>
+</g:if>
 <!-- Kingdom -->
 <alatag:occurrenceTableRow annotate="true" section="taxonomy" fieldCode="kingdom" fieldName="Kingdom">
     ${fieldsMap.put("kingdom", true)}

--- a/grails-app/views/occurrence/show.gsp
+++ b/grails-app/views/occurrence/show.gsp
@@ -23,6 +23,7 @@
 <g:set var="userDisplayName" value="${alatag.loggedInUserDisplayname()}"/>
 <g:set var="userId" value="${alatag.loggedInUserId()}"/>
 <g:set var="isUnderCas" value="${(grailsApplication.config.security.cas.casServerName) ? true : false}"/>
+<g:set var="showVernacularName" value="${grailsApplication.config.getProperty('vernacularName.show', Boolean, true)}"/>
 <!DOCTYPE html>
 <html>
 <head>
@@ -160,10 +161,10 @@
                                 <i>${record.raw.classification.genus} ${record.raw.classification.specificEpithet}</i>
                                 ${record.raw.classification.scientificNameAuthorship}
                             </g:else>
-                            <g:if test="${record.processed.classification.vernacularName}">
+                            <g:if test="${showVernacularName && record.processed.classification.vernacularName}">
                                 | ${record.processed.classification.vernacularName}
                             </g:if>
-                            <g:elseif test="${record.raw.classification.vernacularName}">
+                            <g:elseif test="${showVernacularName && record.raw.classification.vernacularName}">
                                 | ${record.raw.classification.vernacularName}
                             </g:elseif>
                             <g:if test="${record.processed.event?.eventDate || record.raw.event?.eventDate}">


### PR DESCRIPTION
With this PR adding:

```
vernacularName.show=false
```
to the ala-hub config allows to not show vernacular name in search results. By default it does not affect the current behaviour. 

Before:

![image](https://user-images.githubusercontent.com/180085/218069559-c25e8498-a0c8-4b88-890c-0c4d5bb92f67.png)

![image](https://user-images.githubusercontent.com/180085/218059728-3affea53-88b3-47e4-8e01-7b2183a3bde2.png)

After:

![image](https://user-images.githubusercontent.com/180085/218069651-d38c1f91-c165-4f88-ad68-d928e4ea8e5e.png)

![image](https://user-images.githubusercontent.com/180085/218069355-39e859a4-dffb-4e03-b50e-01024ed34a1d.png)

