### PR TITLE
switch to new assertion delete endpoint

### DIFF
--- a/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
+++ b/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
@@ -237,13 +237,26 @@ class WebServicesService {
      * @param assertionUuid
      * @return
      */
-    def Map deleteAssertion(String recordUuid, String assertionUuid) {
-        Map postBody = [
-                recordUuid   : recordUuid,
-                assertionUuid: assertionUuid
-        ]
+    Map deleteAssertion(String recordUuid, String assertionUuid) {
 
-        postFormData(grailsApplication.config.biocache.baseUrl + "/occurrences/assertions/delete", postBody, true, true)
+        String url = grailsApplication.config.getProperty('biocache.baseUrl') + "/occurrences/${recordUuid}/assertions/${assertionUuid}"
+
+        Map result = webService.delete(url, [:], ContentType.APPLICATION_JSON, true, true)
+
+        Map postResponse = [:]
+
+        postResponse.statusCode = result.statusCode
+
+        if (result.error) {
+
+            postResponse.statusMsg = result.error
+
+        } else {
+
+            postResponse.statusMsg = ''
+        }
+
+        return postResponse
     }
 
     @Cacheable('collectoryCache')


### PR DESCRIPTION
The biocahce-service to delete assertions via HTTP POST has been [deprecated](https://github.com/AtlasOfLivingAustralia/biocache-service/blob/e668cf48b6d2883a419c03fba186a8e64cf3560e/src/main/java/au/org/ala/biocache/web/AssertionController.java#L255-L266) and replaces with a more [REStful version](https://github.com/AtlasOfLivingAustralia/biocache-service/blob/e668cf48b6d2883a419c03fba186a8e64cf3560e/src/main/java/au/org/ala/biocache/web/AssertionController.java#L271-L298)