### PR TITLE
bugfix/flagging issue

### DIFF
--- a/grails-app/views/home/index.gsp
+++ b/grails-app/views/home/index.gsp
@@ -147,7 +147,7 @@
             }
         };
 
-        var defaultBaseLayer = L.tileLayer("${grailsApplication.config.map.minimal.url}", {
+        var defaultBaseLayer = L.tileLayer("${grailsApplication.config.getProperty('map.minimal.url')}", {
             attribution: "${raw(grailsApplication.config.getProperty('map.minimal.attr'))}",
             subdomains: "${grailsApplication.config.getProperty('map.minimal.subdomains', String, '')}",
             mapid: "${grailsApplication.config.getProperty('map.mapbox.id', String, '')}",

--- a/grails-app/views/occurrence/_recordSidebar.gsp
+++ b/grails-app/views/occurrence/_recordSidebar.gsp
@@ -1,4 +1,4 @@
-<g:if test="${isUnderCas}">
+<g:if test="${isUnderAuth}">
     <button class="btn btn-default" id="assertionButton" href="#loginOrFlag" role="button" data-toggle="modal" title="report a problem or suggest a correction for this record">
         <span id="loginOrFlagSpan" title="Flag an issue" class=""><i class="glyphicon glyphicon-flag"></i> <g:message code="show.button.assertionbutton.span" default="Flag an issue"/></span>
     </button>

--- a/grails-app/views/occurrence/show.gsp
+++ b/grails-app/views/occurrence/show.gsp
@@ -53,7 +53,6 @@
             recordUuid: "${record.raw.rowKey}",
             taxonRank: "${record.processed.classification.taxonRank}",
             taxonConceptID: "${record.processed.classification.taxonConceptID}",
-            isUnderCas: ${isUnderCas},
             locale: "${org.springframework.web.servlet.support.RequestContextUtils.getLocale(request)}",
             sensitiveDatasets: {
                 <g:each var="sds" in="${sensitiveDatasets}"

--- a/grails-app/views/occurrence/show.gsp
+++ b/grails-app/views/occurrence/show.gsp
@@ -22,7 +22,7 @@
 <g:set var="sensitiveDatasets" value="${sensitiveDatasetRaw?.split(',')}"/>
 <g:set var="userDisplayName" value="${alatag.loggedInUserDisplayname()}"/>
 <g:set var="userId" value="${alatag.loggedInUserId()}"/>
-<g:set var="isUnderCas" value="${grailsApplication.config.getProperty('security.cas.casServerName')}"/>
+<g:set var="isUnderAuth" value="${grailsApplication.config.getProperty('security.cas.enabled', Boolean, false) || grailsApplication.config.getProperty('security.oidc.enabled', Boolean, false)}"/>
 <g:set var="showVernacularName" value="${grailsApplication.config.getProperty('vernacularName.show', Boolean, true)}"/>
 <!DOCTYPE html>
 <html>

--- a/src/main/groovy/au/org/ala/biocache/hubs/SearchRequestParams.groovy
+++ b/src/main/groovy/au/org/ala/biocache/hubs/SearchRequestParams.groovy
@@ -43,7 +43,7 @@ class SearchRequestParams implements Validateable{
     String order // grails version of dir
     String displayString
     /**  The query context to be used for the search.  This will be used to generate extra query filters based on the search technology */
-    String qc = Holders.config.biocache.queryContext?:""
+    String qc = Holders.config.getProperty('biocache.queryContext', String, '')
     /** To disable facets */
     Boolean facet = true
 


### PR DESCRIPTION
changed the `isUnderCas` variable to `isUnderAuth` and configure based on either CAS or OIDC being enabled. 

The flag item bug was caused by the `isUnderCas` JS property being set from a string without surrounding quote characters. This resulted in an invalid JS object which caused functions in `show.js` fail to register jQuery handlers to process the "flag item" submit event. 
https://github.com/AtlasOfLivingAustralia/biocache-hubs/blob/224c40b1a6035a4b44b276f2bcf090643a2d8157/grails-app/views/occurrence/show.gsp#L56

updated extra`grailsApplication.config.getProperty()` method