### PR TITLE
Fix issue when catalogNumber search value contains a colon

### DIFF
--- a/src/main/groovy/au/org/ala/biocache/hubs/AdvancedSearchParams.groovy
+++ b/src/main/groovy/au/org/ala/biocache/hubs/AdvancedSearchParams.groovy
@@ -273,7 +273,7 @@ class AdvancedSearchParams implements Validateable {
      * @return
      */
     private String quoteText(String text) {
-        if (StringUtils.contains(text, " ")) {
+        if (StringUtils.contains(text, " ") || StringUtils.contains(text, ":")) {
             text = QUOTE + text + QUOTE
         }
 


### PR DESCRIPTION
Fixes issue when using advanced search with a catalog-number that contained a colon, together with another field:
https://biocache.ala.org.au/occurrences/search?q=catalogue_number%3Atest%3Atest%3Atest+AND+collector_text%3Atest