### PR TITLE
Change the web-service fetch to include user-context by default

### DIFF
--- a/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
+++ b/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
@@ -80,7 +80,7 @@ class WebServicesService {
 
     def JSONObject getRecord(String id, Boolean hasClubView) {
         def url = "${grailsApplication.config.getProperty('biocache.baseUrl')}/occurrences/${id.encodeAsURL()}?im=true"
-        getJsonElements(url, true, true)
+        getJsonElements(url, false, true)
     }
 
     def JSONObject getCompareRecord(String id) {
@@ -465,7 +465,7 @@ class WebServicesService {
      * @param timeout timeout in milliseconds for the connection and read operations, default is -1 which means no timeout
      * @return the object we request or an JSON object containing error info in case of error
      */
-    JSONElement getJsonElements(String url, Boolean wsAuth = true, Boolean includeUser = true, int timeout = -1) {
+    JSONElement getJsonElements(String url, Boolean wsAuth = false, Boolean includeUser = true, int timeout = -1) {
 
         log.debug "(internal) getJson URL = " + url
         def conn = new URL(url).openConnection()

--- a/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
+++ b/grails-app/services/au/org/ala/biocache/hubs/WebServicesService.groovy
@@ -80,7 +80,7 @@ class WebServicesService {
 
     def JSONObject getRecord(String id, Boolean hasClubView) {
         def url = "${grailsApplication.config.getProperty('biocache.baseUrl')}/occurrences/${id.encodeAsURL()}?im=true"
-        getJsonElements(url, hasClubView, hasClubView)
+        getJsonElements(url, true, true)
     }
 
     def JSONObject getCompareRecord(String id) {
@@ -465,7 +465,7 @@ class WebServicesService {
      * @param timeout timeout in milliseconds for the connection and read operations, default is -1 which means no timeout
      * @return the object we request or an JSON object containing error info in case of error
      */
-    JSONElement getJsonElements(String url, Boolean wsAuth = false, Boolean includeUser = false, int timeout = -1) {
+    JSONElement getJsonElements(String url, Boolean wsAuth = true, Boolean includeUser = true, int timeout = -1) {
 
         log.debug "(internal) getJson URL = " + url
         def conn = new URL(url).openConnection()


### PR DESCRIPTION
Related to: https://github.com/AtlasOfLivingAustralia/biocache-service/pull/988

Make sure that all request to the biocache-service always include the user-context.
Needed for the biocache-service to make the rbac determination and make sure the user only sees the data he has access to. 
Aside from the RBAC thing, it is probably a good idea to always propagate user-context anyway, should help to avoid "confused-deputy" problems.